### PR TITLE
Add MATLAB OOP architecture proposal

### DIFF
--- a/matlab/+pyrpl/+core/ConfigManager.m
+++ b/matlab/+pyrpl/+core/ConfigManager.m
@@ -1,0 +1,136 @@
+classdef ConfigManager < handle
+    %CONFIGMANAGER Load and manage PyRPL MATLAB configuration files.
+    %   The configuration file is a JSON document that contains hardware
+    %   parameters and a list of software modules.  Name/value overrides can
+    %   be applied at construction time to facilitate scripted workflows.
+
+    properties (SetAccess = private)
+        ConfigPath (1, :) char
+        ConfigStruct struct = struct()
+    end
+
+    properties (Access = private)
+        Overrides cell = {}
+    end
+
+    methods
+        function obj = ConfigManager(configPath, varargin)
+            %CONFIGMANAGER Construct a configuration manager.
+            arguments
+                configPath (1, :) char
+            end
+            arguments (Repeating)
+                varargin
+            end
+            obj.ConfigPath = configPath;
+            obj.Overrides = varargin;
+        end
+
+        function load(obj)
+            %LOAD Read the configuration file and apply overrides.
+            if ~isfile(obj.ConfigPath)
+                error('pyrpl:ConfigManager:FileNotFound', ...
+                    'Configuration file "%s" does not exist.', obj.ConfigPath);
+            end
+            jsonText = fileread(obj.ConfigPath);
+            obj.ConfigStruct = jsondecode(jsonText);
+            if ~isempty(obj.Overrides)
+                for k = 1:2:numel(obj.Overrides)
+                    key = obj.Overrides{k};
+                    value = obj.Overrides{k + 1};
+                    obj.ConfigStruct = obj.applyOverride(obj.ConfigStruct, key, value);
+                end
+            end
+        end
+
+        function save(obj, destinationPath)
+            %SAVE Persist the current configuration to disk.
+            if nargin < 2 || isempty(destinationPath)
+                destinationPath = obj.ConfigPath;
+            end
+            jsonText = jsonencode(obj.ConfigStruct, 'PrettyPrint', true);
+            fid = fopen(destinationPath, 'w');
+            if fid < 0
+                error('pyrpl:ConfigManager:WriteError', ...
+                    'Unable to open "%s" for writing.', destinationPath);
+            end
+            cleaner = onCleanup(@() fclose(fid));
+            fwrite(fid, jsonText, 'char'); %#ok<NASGU>
+        end
+
+        function refresh(obj)
+            %REFRESH Reload the configuration from disk discarding overrides.
+            overrides = obj.Overrides;
+            obj.Overrides = {};
+            obj.load();
+            obj.Overrides = overrides;
+        end
+
+        function hwConfig = getHardwareConfig(obj)
+            %GETHARDWARECONFIG Retrieve hardware-specific settings.
+            if ~isfield(obj.ConfigStruct, 'hardware')
+                error('pyrpl:ConfigManager:MissingHardware', ...
+                    'Configuration does not define a hardware section.');
+            end
+            hwConfig = obj.ConfigStruct.hardware;
+        end
+
+        function moduleConfigs = getModuleConfigs(obj)
+            %GETMODULECONFIGS Return the list of module specifications.
+            if ~isfield(obj.ConfigStruct, 'modules')
+                moduleConfigs = struct([]);
+                return
+            end
+            moduleConfigs = obj.ConfigStruct.modules;
+            if ~isstruct(moduleConfigs)
+                error('pyrpl:ConfigManager:InvalidModules', ...
+                    'The "modules" field must be an array of objects.');
+            end
+            if ~isempty(moduleConfigs)
+                moduleConfigs = moduleConfigs(:).';
+            end
+        end
+
+        function value = get(obj, path, defaultValue)
+            %GET Retrieve a configuration value using dot notation.
+            %   value = manager.get('hardware.hostname') returns the hostname.
+            arguments
+                obj
+                path (1, :) char
+                defaultValue = []
+            end
+            tokens = strsplit(path, '.');
+            value = obj.ConfigStruct;
+            for k = 1:numel(tokens)
+                token = tokens{k};
+                if isstruct(value) && isfield(value, token)
+                    value = value.(token);
+                else
+                    value = defaultValue;
+                    return
+                end
+            end
+        end
+    end
+
+    methods (Access = private)
+        function structOut = applyOverride(~, structIn, key, value)
+            tokens = strsplit(key, '.');
+            structOut = pyrpl.core.ConfigManager.setNestedValue(structIn, tokens, value);
+        end
+    end
+
+    methods (Static, Access = private)
+        function s = setNestedValue(s, tokens, value)
+            token = tokens{1};
+            if numel(tokens) == 1
+                s.(token) = value;
+                return
+            end
+            if ~isfield(s, token) || ~isstruct(s.(token))
+                s.(token) = struct();
+            end
+            s.(token) = pyrpl.core.ConfigManager.setNestedValue(s.(token), tokens(2:end), value);
+        end
+    end
+end

--- a/matlab/+pyrpl/+core/Logger.m
+++ b/matlab/+pyrpl/+core/Logger.m
@@ -1,0 +1,83 @@
+classdef Logger < handle
+    %LOGGER Simple printf-style logger with adjustable verbosity.
+    %   The logger writes to MATLAB's command window and can be shared
+    %   across modules.  Supported levels are ``debug``, ``info``,
+    %   ``warning``, and ``error``.
+
+    properties (SetAccess = private)
+        Level (1, 1) double = 2
+    end
+
+    properties (Constant, Access = private)
+        LevelMap = struct('debug', 1, 'info', 2, 'warning', 3, 'error', 4);
+        LevelNames = {'DEBUG', 'INFO', 'WARN', 'ERROR'};
+    end
+
+    methods
+        function obj = Logger(level)
+            %LOGGER Create a new logger instance with the specified level.
+            if nargin < 1
+                level = 'info';
+            end
+            obj.setLevel(level);
+        end
+
+        function setLevel(obj, level)
+            %SETLEVEL Set the logging threshold.
+            if ischar(level) || isstring(level)
+                level = char(lower(string(level)));
+                if ~isfield(obj.LevelMap, level)
+                    error('pyrpl:Logger:InvalidLevel', 'Unknown level: %s', level);
+                end
+                obj.Level = obj.LevelMap.(level);
+            elseif isnumeric(level)
+                obj.Level = max(1, min(4, floor(level)));
+            else
+                error('pyrpl:Logger:InvalidLevelType', 'Unsupported level type.');
+            end
+        end
+
+        function debug(obj, message, varargin)
+            obj.log(1, message, varargin{:});
+        end
+
+        function info(obj, message, varargin)
+            obj.log(2, message, varargin{:});
+        end
+
+        function warning(obj, message, varargin)
+            obj.log(3, message, varargin{:});
+        end
+
+        function error(obj, message, varargin)
+            obj.log(4, message, varargin{:});
+        end
+    end
+
+    methods (Static)
+        function text = toJson(value)
+            %TOJSON Utility to stringify structures for debugging.
+            try
+                text = jsonencode(value, 'PrettyPrint', true);
+            catch
+                text = '<unavailable>';
+            end
+        end
+    end
+
+    methods (Access = private)
+        function log(obj, level, message, varargin)
+            if level < obj.Level
+                return
+            end
+            timestamp = datestr(now, 'yyyy-mm-dd HH:MM:SS.FFF');
+            prefix = obj.LevelNames{level};
+            line = sprintf('[%s] [%s] %s\n', timestamp, prefix, message);
+            if isempty(varargin)
+                fprintf(1, '%s', line);
+            else
+                fprintf(1, line, varargin{:});
+            end
+        end
+    end
+end

--- a/matlab/+pyrpl/+hardware/RedPitayaClient.m
+++ b/matlab/+pyrpl/+hardware/RedPitayaClient.m
@@ -1,0 +1,221 @@
+classdef RedPitayaClient < handle
+    %REDPITAYACLIENT Hardware abstraction layer for Red Pitaya/STEMlab boards.
+    %   The class exposes a MATLAB-friendly API mirroring the Python
+    %   implementation.  When operating in ``mock`` mode, a configurable plant
+    %   model is simulated using Control System Toolbox primitives, enabling
+    %   offline development and automated testing.
+
+    properties (SetAccess = private)
+        Hostname (1, :) char = ''
+        Port (1, 1) double = 5000
+        Timeout (1, 1) double = 5.0
+        SampleRate (1, 1) double = 125e6
+        AnalogInChannels (1, 1) double = 2
+        AnalogOutChannels (1, 1) double = 2
+        IsConnected (1, 1) logical = false
+        MockMode (1, 1) logical = true
+        Logger (1, 1) pyrpl.core.Logger
+    end
+
+    properties (Access = private)
+        TcpClient
+        MockPlant
+        MockState
+        NoiseLevel (1, 1) double = 0.0
+        PhaseNoise (1, 1) double = deg2rad(0.2)
+    end
+
+    methods
+        function obj = RedPitayaClient(config, logger)
+            %REDPITAYACLIENT Constructor using configuration structure.
+            if nargin < 2 || isempty(logger)
+                logger = pyrpl.core.Logger('info');
+            end
+            obj.Logger = logger;
+
+            if isfield(config, 'hostname'); obj.Hostname = config.hostname; end
+            if isfield(config, 'port'); obj.Port = config.port; end
+            if isfield(config, 'timeout'); obj.Timeout = config.timeout; end
+            if isfield(config, 'samplingRate'); obj.SampleRate = config.samplingRate; end
+            if isfield(config, 'analogInChannels'); obj.AnalogInChannels = config.analogInChannels; end
+            if isfield(config, 'analogOutChannels'); obj.AnalogOutChannels = config.analogOutChannels; end
+            if isfield(config, 'mock'); obj.MockMode = config.mock; end
+            if isfield(config, 'noiseLevel'); obj.NoiseLevel = config.noiseLevel; end
+
+            obj.MockState = struct('AnalogOut', zeros(obj.AnalogOutChannels, 1), ...
+                                   'PlantState', []);
+
+            if isfield(config, 'plant')
+                obj.MockPlant = obj.createPlantFromConfig(config.plant);
+            else
+                obj.MockPlant = tf(1, [1/(2*pi*5e3), 1]);
+            end
+        end
+
+        function connect(obj)
+            %CONNECT Establish a TCP connection or prepare the mock backend.
+            if obj.IsConnected
+                return
+            end
+            if obj.MockMode || isempty(obj.Hostname)
+                obj.Logger.debug('RedPitayaClient operating in mock mode.');
+                obj.IsConnected = true;
+                return
+            end
+            try
+                obj.TcpClient = tcpclient(obj.Hostname, obj.Port, 'Timeout', obj.Timeout);
+                obj.IsConnected = true;
+                obj.Logger.info('Connected to Red Pitaya at %s:%d.', obj.Hostname, obj.Port);
+            catch err
+                obj.Logger.warning('Falling back to mock mode: %s', err.message);
+                obj.MockMode = true;
+                obj.IsConnected = true;
+            end
+        end
+
+        function disconnect(obj)
+            %DISCONNECT Release the TCP connection.
+            if obj.MockMode
+                obj.IsConnected = false;
+                return
+            end
+            if isempty(obj.TcpClient)
+                obj.IsConnected = false;
+                return
+            end
+            try
+                clear obj.TcpClient;
+            catch
+            end
+            obj.TcpClient = [];
+            obj.IsConnected = false;
+        end
+
+        function setAnalogOut(obj, channel, value)
+            %SETANALOGOUT Set the DC value of an analog output.
+            obj.validateChannel(channel, obj.AnalogOutChannels, 'output');
+            if obj.MockMode
+                obj.MockState.AnalogOut(channel) = value;
+                return
+            end
+            % Implement hardware-specific command sequence here.
+            error('RedPitayaClient:setAnalogOut:NotImplemented', ...
+                'Direct hardware control is not implemented in this example.');
+        end
+
+        function configureSineOutput(obj, channel, amplitude, frequency, offset)
+            %CONFIGURESINEOUTPUT Configure a sinewave excitation on an analog output.
+            if nargin < 5
+                offset = 0;
+            end
+            obj.validateChannel(channel, obj.AnalogOutChannels, 'output');
+            if obj.MockMode
+                obj.MockState.Sine(channel) = struct( ...
+                    'Amplitude', amplitude, ...
+                    'Frequency', frequency, ...
+                    'Offset', offset);
+                return
+            end
+            error('RedPitayaClient:configureSineOutput:NotImplemented', ...
+                'Direct hardware control is not implemented in this example.');
+        end
+
+        function data = acquireAnalogIn(obj, channel, numSamples)
+            %ACQUIREANALOGIN Capture analog input samples.
+            arguments
+                obj
+                channel (1, 1) double
+                numSamples (1, 1) double {mustBePositive} = 2^14
+            end
+            obj.validateChannel(channel, obj.AnalogInChannels, 'input');
+            if obj.MockMode
+                data = obj.generateMockAnalogInput(channel, numSamples);
+                return
+            end
+            error('RedPitayaClient:acquireAnalogIn:NotImplemented', ...
+                'Direct hardware acquisition is not implemented in this example.');
+        end
+
+        function response = measureFrequencyResponse(obj, frequencyHz, amplitude)
+            %MEASUREFREQUENCYRESPONSE Estimate the plant response at a frequency.
+            %   response is a struct with fields frequency, gain, and phase (rad).
+            if nargin < 3
+                amplitude = 1.0;
+            end
+            if obj.MockMode
+                w = 2 * pi * frequencyHz;
+                H = squeeze(freqresp(obj.MockPlant, w));
+                gain = abs(H);
+                phase = angle(H);
+                response.frequency = frequencyHz;
+                response.gain = gain;
+                response.outputAmplitude = amplitude * gain + obj.NoiseLevel * randn();
+                response.phase = phase + obj.PhaseNoise * randn();
+                return
+            end
+            error('RedPitayaClient:measureFrequencyResponse:NotImplemented', ...
+                'Direct hardware frequency response is not implemented in this example.');
+        end
+
+        function plant = getMockPlant(obj)
+            %GETMOCKPLANT Accessor for the simulated plant (useful for modules).
+            plant = obj.MockPlant;
+        end
+    end
+
+    methods (Access = private)
+        function validateChannel(~, channel, limit, label)
+            if channel < 1 || channel > limit
+                error('pyrpl:RedPitayaClient:ChannelOutOfRange', ...
+                    'Analog %s channel %d out of range 1..%d.', label, channel, limit);
+            end
+        end
+
+        function data = generateMockAnalogInput(obj, channel, numSamples)
+            if nargin < 3
+                numSamples = 2^14;
+            end
+            t = (0:numSamples-1).' / obj.SampleRate;
+            inputSignal = zeros(numSamples, 1);
+            if isfield(obj.MockState, 'Sine')
+                sineStates = obj.MockState.Sine;
+                sineChannels = fieldnames(sineStates);
+                for k = 1:numel(sineChannels)
+                    state = sineStates.(sineChannels{k});
+                    inputSignal = inputSignal + state.Amplitude * sin(2*pi*state.Frequency*t) + state.Offset;
+                end
+            else
+                excitationFreq = 10e3;
+                inputSignal = 0.1 * sin(2*pi*excitationFreq*t);
+            end
+            [y, ~, x] = lsim(obj.MockPlant, inputSignal, t, obj.MockState.PlantState);
+            if isempty(x)
+                obj.MockState.PlantState = [];
+            else
+                obj.MockState.PlantState = x(end, :).';
+            end
+            noise = obj.NoiseLevel * randn(size(y));
+            data = y + noise;
+            if channel == 2
+                data = data + 0.02 * sin(2*pi*2e3*t);
+            end
+        end
+
+        function plant = createPlantFromConfig(~, config)
+            zerosVec = []; polesVec = []; gain = 1;
+            if isfield(config, 'zeros'); zerosVec = config.zeros(:); end
+            if isfield(config, 'poles'); polesVec = config.poles(:); end
+            if isfield(config, 'gain'); gain = config.gain; end
+            s = tf('s');
+            numerator = gain;
+            denominator = 1;
+            for k = 1:numel(zerosVec)
+                numerator = numerator * (s - zerosVec(k));
+            end
+            for k = 1:numel(polesVec)
+                denominator = denominator * (s - polesVec(k));
+            end
+            plant = numerator / denominator;
+        end
+    end
+end

--- a/matlab/+pyrpl/+modules/Lockbox.m
+++ b/matlab/+pyrpl/+modules/Lockbox.m
@@ -1,0 +1,127 @@
+classdef Lockbox < pyrpl.modules.Module
+    %LOCKBOX Digital lockbox module implementing PID control.
+    %   Provides discrete-time PID control with optional simulation tools for
+    %   tuning controller parameters against the mock plant.  The controller is
+    %   realized as a discrete transfer function obtained via bilinear
+    %   transformation of a continuous-time PID specification.
+
+    properties (Access = private)
+        InputChannel (1, 1) double = 1
+        OutputChannel (1, 1) double = 1
+        Setpoint (1, 1) double = 0.0
+        ControllerConfig struct = struct()
+        SearchConfig struct = struct('strategy', 'raster', 'range', 0.5, 'speed', 0.05)
+        SimulationConfig struct = struct('duration', 0.02, 'disturbanceAmplitude', 0.05)
+        SampleTime (1, 1) double = 1e-6
+        ControllerB double = 0
+        ControllerA double = 1
+        ControllerState double = 0
+        ContinuousController
+        LastSimulation struct = struct()
+    end
+
+    methods
+        function obj = Lockbox(app, name, config)
+            obj@pyrpl.modules.Module(app, name, config);
+        end
+
+        function setup(obj)
+            setup@pyrpl.modules.Module(obj);
+            cfg = obj.Config;
+            hw = obj.App.Hardware;
+            obj.SampleTime = 1 / hw.SampleRate;
+            if isfield(cfg, 'inputChannel'); obj.InputChannel = cfg.inputChannel; end
+            if isfield(cfg, 'outputChannel'); obj.OutputChannel = cfg.outputChannel; end
+            if isfield(cfg, 'setpoint'); obj.Setpoint = cfg.setpoint; end
+            if isfield(cfg, 'controller'); obj.ControllerConfig = cfg.controller; end
+            if isfield(cfg, 'search'); obj.SearchConfig = cfg.search; end
+            if isfield(cfg, 'simulation'); obj.SimulationConfig = cfg.simulation; end
+            obj.configureController();
+        end
+
+        function start(obj)
+            start@pyrpl.modules.Module(obj);
+            obj.resetControllerState();
+        end
+
+        function output = update(obj, measurement)
+            %UPDATE Compute the new actuator value for the provided measurement.
+            errorSignal = obj.Setpoint - measurement;
+            output = obj.applyController(errorSignal);
+            try
+                obj.App.Hardware.setAnalogOut(obj.OutputChannel, output);
+            catch controlErr
+                obj.App.Logger.debug('Lockbox output dispatch skipped: %s', controlErr.message);
+            end
+            notify(obj, 'Updated');
+        end
+
+        function simulation = simulateLock(obj, duration)
+            %SIMULATELOCK Simulate the closed-loop response using the mock plant.
+            if nargin < 2 || isempty(duration)
+                if isfield(obj.SimulationConfig, 'duration')
+                    duration = obj.SimulationConfig.duration;
+                else
+                    duration = 0.02;
+                end
+            end
+            plant = obj.App.Hardware.getMockPlant();
+            controller = obj.ContinuousController;
+            closedLoop = feedback(controller * plant, 1);
+            Ts = obj.SampleTime;
+            t = 0:Ts:duration;
+            disturbanceAmplitude = 0;
+            if isfield(obj.SimulationConfig, 'disturbanceAmplitude')
+                disturbanceAmplitude = obj.SimulationConfig.disturbanceAmplitude;
+            end
+            disturbance = disturbanceAmplitude * square(2*pi*50*t);
+            [y, tOut] = lsim(closedLoop, disturbance, t);
+            simulation = struct('time', tOut, 'output', y, 'disturbance', disturbance, ...
+                                'controller', controller, 'plant', plant);
+            obj.LastSimulation = simulation;
+        end
+
+        function searchProfile = search(obj, range)
+            %SEARCH Perform a coarse scan over the actuator output.
+            if nargin < 2 || isempty(range)
+                if isfield(obj.SearchConfig, 'range')
+                    range = obj.SearchConfig.range;
+                else
+                    range = 0.5;
+                end
+            end
+            points = 200;
+            actuator = linspace(-range, range, points);
+            plant = obj.App.Hardware.getMockPlant();
+            dcGain = dcgain(plant);
+            measurements = actuator * dcGain;
+            searchProfile = struct('actuator', actuator, 'measurement', measurements, 'dcGain', dcGain);
+        end
+    end
+
+    methods (Access = private)
+        function configureController(obj)
+            cfg = obj.ControllerConfig;
+            if ~isfield(cfg, 'proportional'); cfg.proportional = 0.1; end
+            if ~isfield(cfg, 'integral'); cfg.integral = 100.0; end
+            if ~isfield(cfg, 'derivative'); cfg.derivative = 0.0; end
+            if ~isfield(cfg, 'filterCoefficient'); cfg.filterCoefficient = 100.0; end
+            obj.ControllerConfig = cfg;
+            obj.ContinuousController = pid(cfg.proportional, cfg.integral, cfg.derivative, cfg.filterCoefficient);
+            discrete = c2d(obj.ContinuousController, obj.SampleTime, 'tustin');
+            [b, a] = tfdata(discrete, 'v');
+            obj.ControllerB = b;
+            obj.ControllerA = a;
+            obj.ControllerState = zeros(max(numel(a), numel(b)) - 1, 1);
+        end
+
+        function resetControllerState(obj)
+            obj.ControllerState(:) = 0;
+        end
+
+        function output = applyController(obj, errorSignal)
+            [y, obj.ControllerState] = filter(obj.ControllerB, obj.ControllerA, errorSignal, obj.ControllerState);
+            output = y(end);
+        end
+    end
+end

--- a/matlab/+pyrpl/+modules/Module.m
+++ b/matlab/+pyrpl/+modules/Module.m
@@ -1,0 +1,72 @@
+classdef (Abstract) Module < handle
+    %MODULE Abstract base class for MATLAB implementations of PyRPL modules.
+    %   Derived modules implement ``setup``, ``start``, and ``stop`` methods and
+    %   can optionally override ``update`` to execute periodic logic.
+
+    properties (SetAccess = immutable)
+        App (1, 1) pyrpl.PyrplApp
+        Name (1, :) char
+    end
+
+    properties (SetAccess = protected)
+        Config struct
+        IsSetup (1, 1) logical = false
+        IsRunning (1, 1) logical = false
+    end
+
+    events
+        Started
+        Stopped
+        Updated
+    end
+
+    methods
+        function obj = Module(app, name, config)
+            arguments
+                app (1, 1) pyrpl.PyrplApp
+                name (1, :) char
+                config struct = struct()
+            end
+            obj.App = app;
+            obj.Name = name;
+            obj.Config = config;
+        end
+
+        function setup(obj)
+            %SETUP Prepare the module (override in subclasses).
+            obj.IsSetup = true;
+        end
+
+        function start(obj)
+            %START Begin module execution (override in subclasses if needed).
+            if ~obj.IsSetup
+                obj.setup();
+            end
+            obj.IsRunning = true;
+            notify(obj, 'Started');
+        end
+
+        function stop(obj)
+            %STOP Halt module activity (override in subclasses if needed).
+            if ~obj.IsRunning
+                return
+            end
+            obj.IsRunning = false;
+            notify(obj, 'Stopped');
+        end
+
+        function update(obj, varargin)
+            %UPDATE Optional periodic update callback.
+            %#ok<INUSD>
+            notify(obj, 'Updated');
+        end
+
+        function applyConfig(obj, newConfig)
+            %APPLYCONFIG Update the module configuration.
+            obj.Config = newConfig;
+            if obj.IsSetup
+                obj.setup();
+            end
+        end
+    end
+end

--- a/matlab/+pyrpl/+modules/NetworkAnalyzer.m
+++ b/matlab/+pyrpl/+modules/NetworkAnalyzer.m
@@ -1,0 +1,55 @@
+classdef NetworkAnalyzer < pyrpl.modules.Module
+    %NETWORKANALYZER Frequency response measurement module.
+    %   The MATLAB implementation performs swept-sine measurements either
+    %   using the hardware back-end or by interrogating the simulated plant in
+    %   mock mode.
+
+    properties (Access = private)
+        WindowFunction (1, :) char = 'hann'
+        SettlingCycles (1, 1) double = 10
+        ExcitationAmplitude (1, 1) double = 0.1
+        OutputChannel (1, 1) double = 1
+        InputChannel (1, 1) double = 1
+    end
+
+    methods
+        function obj = NetworkAnalyzer(app, name, config)
+            obj@pyrpl.modules.Module(app, name, config);
+        end
+
+        function setup(obj)
+            setup@pyrpl.modules.Module(obj);
+            cfg = obj.Config;
+            if isfield(cfg, 'window'); obj.WindowFunction = cfg.window; end
+            if isfield(cfg, 'settlingCycles'); obj.SettlingCycles = cfg.settlingCycles; end
+            if isfield(cfg, 'excitationAmplitude'); obj.ExcitationAmplitude = cfg.excitationAmplitude; end
+            if isfield(cfg, 'outputChannel'); obj.OutputChannel = cfg.outputChannel; end
+            if isfield(cfg, 'inputChannel'); obj.InputChannel = cfg.inputChannel; end
+        end
+
+        function result = sweep(obj, frequencies)
+            %SWEEP Perform a frequency sweep returning gain and phase vectors.
+            arguments
+                obj
+                frequencies (:, 1) double
+            end
+            hw = obj.App.Hardware;
+            gain = zeros(size(frequencies));
+            phase = zeros(size(frequencies));
+            outputAmplitude = zeros(size(frequencies));
+            for k = 1:numel(frequencies)
+                response = hw.measureFrequencyResponse(frequencies(k), obj.ExcitationAmplitude);
+                gain(k) = response.gain;
+                phase(k) = response.phase;
+                outputAmplitude(k) = response.outputAmplitude;
+            end
+            result = struct('frequency', frequencies, ...
+                            'gain', gain, ...
+                            'phase', phase, ...
+                            'outputAmplitude', outputAmplitude, ...
+                            'window', obj.WindowFunction, ...
+                            'excitationAmplitude', obj.ExcitationAmplitude, ...
+                            'settlingCycles', obj.SettlingCycles);
+        end
+    end
+end

--- a/matlab/+pyrpl/+modules/SpectrumAnalyzer.m
+++ b/matlab/+pyrpl/+modules/SpectrumAnalyzer.m
@@ -1,0 +1,70 @@
+classdef SpectrumAnalyzer < pyrpl.modules.Module
+    %SPECTRUMANALYZER Estimate single-sided amplitude spectrum.
+    %   Uses the mock hardware backend for synthetic data when no hardware is
+    %   connected.  The implementation relies on MATLAB's Signal Processing
+    %   Toolbox for window generation.
+
+    properties (Access = private)
+        InputChannel (1, 1) double = 1
+        FFTLength (1, 1) double = 4096
+        WindowType (1, :) char = 'hann'
+        Averages (1, 1) double = 4
+        RefreshRate (1, 1) double = 5.0
+        LastSpectrum struct = struct()
+    end
+
+    methods
+        function obj = SpectrumAnalyzer(app, name, config)
+            obj@pyrpl.modules.Module(app, name, config);
+        end
+
+        function setup(obj)
+            setup@pyrpl.modules.Module(obj);
+            cfg = obj.Config;
+            if isfield(cfg, 'inputChannel'); obj.InputChannel = cfg.inputChannel; end
+            if isfield(cfg, 'fftLength'); obj.FFTLength = cfg.fftLength; end
+            if isfield(cfg, 'window'); obj.WindowType = cfg.window; end
+            if isfield(cfg, 'averages'); obj.Averages = cfg.averages; end
+            if isfield(cfg, 'refreshRate'); obj.RefreshRate = cfg.refreshRate; end
+        end
+
+        function spectrum = acquire(obj)
+            %ACQUIRE Compute an averaged power spectrum.
+            hw = obj.App.Hardware;
+            fs = hw.SampleRate;
+            n = obj.FFTLength;
+            win = obj.createWindow(n);
+            acc = zeros(n/2+1, 1);
+            for k = 1:obj.Averages
+                data = hw.acquireAnalogIn(obj.InputChannel, n);
+                windowed = data .* win;
+                fftData = fft(windowed);
+                psd = (abs(fftData(1:n/2+1)).^2) / (sum(win.^2) * fs);
+                psd(2:end-1) = 2 * psd(2:end-1);
+                acc = acc + psd;
+            end
+            meanPsd = acc / obj.Averages;
+            freq = (0:n/2)' * (fs / n);
+            spectrum = struct('frequency', freq, 'psd', meanPsd, 'window', obj.WindowType, ...
+                              'fftLength', obj.FFTLength, 'averages', obj.Averages);
+            obj.LastSpectrum = spectrum;
+        end
+    end
+
+    methods (Access = private)
+        function w = createWindow(obj, n)
+            switch lower(obj.WindowType)
+                case 'hann'
+                    w = hann(n, 'periodic');
+                case 'hamming'
+                    w = hamming(n, 'periodic');
+                case 'blackman'
+                    w = blackman(n, 'periodic');
+                otherwise
+                    warning('pyrpl:SpectrumAnalyzer:UnknownWindow', ...
+                        'Unknown window %s, using rectangular.', obj.WindowType);
+                    w = ones(n, 1);
+            end
+        end
+    end
+end

--- a/matlab/+pyrpl/PyrplApp.m
+++ b/matlab/+pyrpl/PyrplApp.m
@@ -1,0 +1,208 @@
+classdef PyrplApp < handle
+    %PYRPLAPP High-level MATLAB front-end for the PyRPL feature set.
+    %   This class orchestrates configuration management, hardware access,
+    %   and software modules.  It mirrors the responsibilities of the
+    %   Python :mod:`pyrpl.pyrpl` module while embracing MATLAB OOP.
+    %
+    %   Example
+    %   -------
+    %   .. code-block:: matlab
+    %
+    %       app = pyrpl.PyrplApp('config/my_lab.json');
+    %       app.initialize();
+    %       app.start();
+    %       lockbox = app.getModule('Lockbox');
+    %       result = lockbox.simulateLock();
+    %       app.stop();
+    %
+    %   The implementation supports both real hardware connections and a
+    %   mock simulation backend that enables development without access to
+    %   a Red Pitaya board.
+
+    properties (SetAccess = private)
+        ConfigManager (1,1) pyrpl.core.ConfigManager
+        Logger (1,1) pyrpl.core.Logger
+        Hardware (1,1) pyrpl.hardware.RedPitayaClient
+        Modules
+        IsInitialized (1,1) logical = false
+        IsRunning (1,1) logical = false
+    end
+
+    properties (Access = private)
+        DefaultConfigPath (1, :) char
+    end
+
+    methods
+        function obj = PyrplApp(configPath, varargin)
+            %PyrplApp Construct the application instance.
+            %   app = pyrpl.PyrplApp() loads the default configuration
+            %   located under matlab/config/default_config.json.
+            %
+            %   app = pyrpl.PyrplApp(configPath) loads a custom
+            %   configuration file.  Additional name/value pairs are
+            %   forwarded to the ConfigManager to override parameters at
+            %   run time.
+            arguments
+                configPath (1, :) char = ''
+            end
+            arguments (Repeating)
+                varargin
+            end
+
+            obj.DefaultConfigPath = fullfile(fileparts(mfilename('fullpath')), ...
+                'config', 'default_config.json');
+            if isempty(configPath)
+                configPath = obj.DefaultConfigPath;
+            end
+
+            obj.Logger = pyrpl.core.Logger('info');
+            obj.ConfigManager = pyrpl.core.ConfigManager(configPath, varargin{:});
+            obj.Modules = containers.Map('KeyType', 'char', 'ValueType', 'any');
+        end
+
+        function initialize(obj)
+            %INITIALIZE Load configuration and instantiate modules.
+            if obj.IsInitialized
+                obj.Logger.debug('Initialization skipped: already initialized.');
+                return
+            end
+
+            obj.Logger.info('Loading configuration from %s', obj.ConfigManager.ConfigPath);
+            obj.ConfigManager.load();
+
+            hwConfig = obj.ConfigManager.getHardwareConfig();
+            obj.Logger.debug('Hardware configuration loaded: %s', pyrpl.core.Logger.toJson(hwConfig));
+            obj.Hardware = pyrpl.hardware.RedPitayaClient(hwConfig, obj.Logger);
+            obj.Hardware.connect();
+
+            obj.Logger.info('Creating software modules.');
+            moduleConfigs = obj.ConfigManager.getModuleConfigs();
+            for k = 1:numel(moduleConfigs)
+                spec = moduleConfigs(k);
+                moduleInstance = obj.instantiateModule(spec);
+                obj.Modules(spec.name) = moduleInstance;
+                obj.Logger.debug('Module "%s" initialized.', spec.name);
+            end
+
+            obj.IsInitialized = true;
+        end
+
+        function start(obj)
+            %START Activate all modules.
+            if ~obj.IsInitialized
+                obj.initialize();
+            end
+            if obj.IsRunning
+                obj.Logger.debug('Start request ignored: application already running.');
+                return
+            end
+
+            if ~obj.Hardware.IsConnected
+                obj.Hardware.connect();
+            end
+
+            moduleNames = obj.Modules.keys;
+            for k = 1:numel(moduleNames)
+                module = obj.Modules(moduleNames{k});
+                module.start();
+            end
+
+            obj.IsRunning = true;
+            obj.Logger.info('All modules started.');
+        end
+
+        function stop(obj)
+            %STOP Deactivate modules and release hardware resources.
+            if ~obj.IsRunning
+                obj.Logger.debug('Stop request ignored: application already stopped.');
+                return
+            end
+
+            moduleNames = obj.Modules.keys;
+            for k = 1:numel(moduleNames)
+                module = obj.Modules(moduleNames{k});
+                module.stop();
+            end
+
+            obj.Hardware.disconnect();
+            obj.IsRunning = false;
+            obj.Logger.info('Application stopped.');
+        end
+
+        function module = getModule(obj, name)
+            %GETMODULE Retrieve an instantiated module by name.
+            arguments
+                obj
+                name (1, :) char
+            end
+            if ~isKey(obj.Modules, name)
+                error('pyrpl:PyrplApp:ModuleNotFound', 'Module "%s" is not registered.', name);
+            end
+            module = obj.Modules(name);
+        end
+
+        function modules = listModules(obj)
+            %LISTMODULES Return the registered modules as a cell array of names.
+            modules = obj.Modules.keys;
+        end
+
+        function addModule(obj, moduleInstance)
+            %ADDMODULE Register an additional module at run time.
+            arguments
+                obj
+                moduleInstance (1, 1) pyrpl.modules.Module
+            end
+            name = moduleInstance.Name;
+            if isKey(obj.Modules, name)
+                warning('pyrpl:PyrplApp:ModuleExists', ...
+                    'Module "%s" already exists and will be replaced.', name);
+            end
+            obj.Modules(name) = moduleInstance;
+        end
+
+        function reloadConfiguration(obj)
+            %RELOADCONFIGURATION Reload configuration and reinitialize modules.
+            obj.Logger.info('Reloading configuration.');
+            wasRunning = obj.IsRunning;
+            obj.stop();
+            obj.Modules = containers.Map('KeyType', 'char', 'ValueType', 'any');
+            obj.IsInitialized = false;
+            obj.initialize();
+            if wasRunning
+                obj.start();
+            end
+        end
+
+        function delete(obj)
+            %DELETE Destructor to ensure resources are released.
+            try %#ok<TRYNC>
+                obj.stop();
+            end
+        end
+    end
+
+    methods (Access = private)
+        function moduleInstance = instantiateModule(obj, spec)
+            %INSTANTIATEMODULE Create a module from a configuration specification.
+            if ~isfield(spec, 'class')
+                error('pyrpl:PyrplApp:MissingClass', 'Module specification must define a class field.');
+            end
+            if ~isfield(spec, 'name')
+                error('pyrpl:PyrplApp:MissingName', 'Module specification must define a name field.');
+            end
+            if ~isfield(spec, 'config')
+                spec.config = struct();
+            end
+
+            constructor = str2func(spec.class);
+            try
+                moduleInstance = constructor(obj, spec.name, spec.config);
+                moduleInstance.setup();
+            catch err
+                obj.Logger.error('Failed to initialize module %s (%s): %s', ...
+                    spec.name, spec.class, err.message);
+                rethrow(err);
+            end
+        end
+    end
+end

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -1,0 +1,33 @@
+# MATLAB Port Architecture Proposal
+
+This directory contains a proposed MATLAB® object-oriented architecture for a
+future re-implementation of PyRPL.  The goal is to retain the modular, hardware
+agnostic design of the Python project while providing classes that follow MATLAB
+OOP best practices.  The proposal focuses on three layers:
+
+1. **Core services** (configuration and logging).
+2. **Hardware abstraction** for the Red Pitaya / STEMlab platform.
+3. **Software modules** that implement measurement and control features such as
+   the network analyzer, spectrum analyzer, and lockbox.
+
+The classes are delivered as MATLAB packages (e.g. `+pyrpl/+modules`) so that
+name spaces mirror the Python package structure.  Each class contains rich
+documentation and inline comments to describe how the MATLAB implementation can
+interact with existing FPGA bitstreams or with simulated hardware for offline
+development.
+
+To try the architecture from MATLAB, add the `matlab` directory to the path and
+instantiate the main application object:
+
+```matlab
+addpath(genpath('path/to/pyrpl/matlab'));
+app = pyrpl.PyrplApp();
+app.initialize();
+app.start();
+network = app.getModule('NetworkAnalyzer');
+sweep = network.sweep(logspace(2, 5, 200));
+```
+
+The configuration file `config/default_config.json` can be edited to adapt the
+hardware connection parameters or to change which software modules are
+initialized at start-up.

--- a/matlab/config/default_config.json
+++ b/matlab/config/default_config.json
@@ -1,0 +1,71 @@
+{
+  "hardware": {
+    "hostname": "",
+    "port": 5000,
+    "timeout": 5.0,
+    "mock": true,
+    "samplingRate": 125000000,
+    "analogInChannels": 2,
+    "analogOutChannels": 2,
+    "noiseLevel": 0.002,
+    "plant": {
+      "zeros": [
+        -62831.853071795864
+      ],
+      "poles": [
+        -628318.5307179586,
+        -1256637.0614359173
+      ],
+      "gain": 2.0e5
+    }
+  },
+  "modules": [
+    {
+      "name": "NetworkAnalyzer",
+      "class": "pyrpl.modules.NetworkAnalyzer",
+      "config": {
+        "outputChannel": 1,
+        "inputChannel": 1,
+        "excitationAmplitude": 0.05,
+        "settlingCycles": 20,
+        "window": "hann"
+      }
+    },
+    {
+      "name": "SpectrumAnalyzer",
+      "class": "pyrpl.modules.SpectrumAnalyzer",
+      "config": {
+        "inputChannel": 1,
+        "fftLength": 8192,
+        "window": "hann",
+        "averages": 4,
+        "refreshRate": 5.0
+      }
+    },
+    {
+      "name": "Lockbox",
+      "class": "pyrpl.modules.Lockbox",
+      "config": {
+        "inputChannel": 1,
+        "outputChannel": 1,
+        "setpoint": 0.0,
+        "controller": {
+          "type": "pid",
+          "proportional": 0.2,
+          "integral": 5000.0,
+          "derivative": 0.0,
+          "filterCoefficient": 1000.0
+        },
+        "search": {
+          "strategy": "raster",
+          "range": 0.5,
+          "speed": 0.05
+        },
+        "simulation": {
+          "duration": 0.02,
+          "disturbanceAmplitude": 0.05
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a MATLAB-based application shell that wires configuration, logging, hardware access, and module management
- implement core services plus a simulated Red Pitaya hardware client for offline development
- include example software modules (network analyzer, spectrum analyzer, lockbox) together with documentation and default configuration

## Testing
- not run (MATLAB code)


------
https://chatgpt.com/codex/tasks/task_e_68ced7cb7760832cb1111d40b533eb64